### PR TITLE
docs(create_infra_env): add offline_token to module options

### DIFF
--- a/plugins/modules/create_infra_env.py
+++ b/plugins/modules/create_infra_env.py
@@ -54,6 +54,10 @@ options:
         description: Name of the infra-env.
         required: false
         type: str
+    offline_token:
+        description: Offline token from console.redhat.com
+        required: true
+        type: str
     openshift_version:
         description: Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
         required: false

--- a/plugins/modules/wait_for_hosts.py
+++ b/plugins/modules/wait_for_hosts.py
@@ -30,6 +30,11 @@ options:
         description: The infra-env ID of the host to be updated. Required with hosts are assigned.
         required: false
         type: str
+        default: 10
+    offline_token:
+        description: Offline token from console.redhat.com
+        required: true
+        type: str
     expected_hosts:
         description: Expected number of the hosts
         required: true
@@ -43,7 +48,6 @@ options:
         description: Delay time between checks
         required: False
         type: int
-        default: 10
 
 author:
     - Alberto Gonzalez (@agonzalezrh)

--- a/plugins/modules/wait_for_hosts.py
+++ b/plugins/modules/wait_for_hosts.py
@@ -30,7 +30,6 @@ options:
         description: The infra-env ID of the host to be updated. Required with hosts are assigned.
         required: false
         type: str
-        default: 10
     offline_token:
         description: Offline token from console.redhat.com
         required: true
@@ -48,6 +47,7 @@ options:
         description: Delay time between checks
         required: False
         type: int
+        default: 10
 
 author:
     - Alberto Gonzalez (@agonzalezrh)


### PR DESCRIPTION
Improve IDE user experience by adding the missing but required `offline_token` option for the `create_infra_env` module so that it will be highlighted and tooltip'ed correctly.